### PR TITLE
Add Configurable Default Flash Messages

### DIFF
--- a/.byebugrc
+++ b/.byebugrc
@@ -1,1 +1,1 @@
-set history save off
+set noautosave

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-rest-kit (0.2.0)
+    rails-rest-kit (0.3.0)
       rails (~> 7.0, >= 7.0.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails-rest-kit (0.1.0)
+    rails-rest-kit (0.2.0)
       rails (~> 7.0, >= 7.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ Or install it yourself as:
 $ gem install rails-rest-kit
 ```
 
+## Configuration
+Configure default flash messages:
+```ruby
+RailsRestKit.configure do |config|
+  config.flash_defaults.create_valid(flash_type: :alert, message: "Successfully created!")
+end
+```
+You can also configure the flash message with a block:
+```ruby
+RailsRestKit.configure do |config|
+  config.flash_defaults.create_valid(flash_type: :alert, message: -> (resource) { "#{resource.model_name} successfully created!" })
+end
+```
+
 ## Usage
 Include the `RailsRestKit::RestfulControllerActions` module in your controller. Your controller will now be defined with all REST actions (`index, show, new, create, edit, update, destroy`), and perform typical CRUD behavior:
 

--- a/lib/rails_rest_kit.rb
+++ b/lib/rails_rest_kit.rb
@@ -1,4 +1,5 @@
 require "rails_rest_kit/version"
+require "rails_rest_kit/configuration"
 require "rails_rest_kit/helpers/resource_helper"
 require "rails_rest_kit/helpers/permitter_helper"
 require "rails_rest_kit/restful_controller_actions"

--- a/lib/rails_rest_kit/configuration.rb
+++ b/lib/rails_rest_kit/configuration.rb
@@ -1,0 +1,7 @@
+require "rails_rest_kit/flash_defaults"
+
+module RailsRestKit
+  include ActiveSupport::Configurable
+
+  config_accessor(:flash_defaults) { FlashDefaults.instance }
+end

--- a/lib/rails_rest_kit/flash_defaults.rb
+++ b/lib/rails_rest_kit/flash_defaults.rb
@@ -8,10 +8,10 @@ module RailsRestKit
         message: -> (resource) { "#{resource.model_name.human} was successfully created." } 
       }
       if params.nil?
-        @default_create_valid ||= Default.new(default_params)
+        @default_create_valid ||= Default.new(**default_params)
       else
         params.reverse_merge!(default_params)
-        @default_create_valid = Default.new(params[:type], params[:message])
+        @default_create_valid = Default.new(**params)
       end
     end
 
@@ -21,10 +21,10 @@ module RailsRestKit
         message: -> (resource) { "#{resource.model_name.human} failed to be created." } 
       }
       if params.nil?
-        @default_create_invalid ||= Default.new(default_params)
+        @default_create_invalid ||= Default.new(**default_params)
       else
         params.reverse_merge!(default_params)
-        @default_create_invalid = Default.new(params[:type], params[:message])
+        @default_create_invalid = Default.new(**params)
       end
     end
 
@@ -34,10 +34,10 @@ module RailsRestKit
         message: -> (resource) { "#{resource.model_name.human} was successfully updated." } 
       }
       if params.nil?
-        @default_update_valid ||= Default.new(default_params)
+        @default_update_valid ||= Default.new(**default_params)
       else
         params.reverse_merge!(default_params)
-        @default_update_valid = Default.new(params[:type], params[:message])
+        @default_update_valid = Default.new(**params)
       end
     end
 
@@ -47,23 +47,36 @@ module RailsRestKit
         message: -> (resource) { "#{resource.model_name.human} failed to be updated." } 
       }
       if params.nil?
-        @default_update_invalid ||= Default.new(default_params)
+        @default_update_invalid ||= Default.new(**default_params)
       else
         params.reverse_merge!(default_params)
-        @default_update_invalid = Default.new(params[:type], params[:message])
+        @default_update_invalid = Default.new(**params)
       end
     end
 
-    def destroy(params = nil)
+    def destroy_valid(params = nil)
       default_params = { 
         type: :notice, 
         message: -> (resource) { "#{resource.model_name.human} was successfully destroyed." } 
       }
       if params.nil?
-        @default_destroy ||= Default.new(default_params)
+        @default_destroy ||= Default.new(**default_params)
       else
         params.reverse_merge!(default_params)
-        @default_destroy = Default.new(params[:type], params[:message])
+        @default_destroy = Default.new(**params)
+      end
+    end
+
+    def destroy_invalid(params = nil)
+      default_params = { 
+        type: :alert, 
+        message: -> (resource) { "#{resource.model_name.human} failed to be destroyed." } 
+      }
+      if params.nil?
+        @default_destroy_invalid ||= Default.new(**default_params)
+      else
+        params.reverse_merge!(default_params)
+        @default_destroy_invalid = Default.new(**params)
       end
     end
 
@@ -74,9 +87,9 @@ module RailsRestKit
     class Default
       attr_accessor :flash_type, :message_or_block
 
-      def initialize(flash_type, message_or_block)
-        @flash_type = flash_type
-        @message_or_block = message_or_block
+      def initialize(type:, message:)
+        @flash_type = type
+        @message_or_block = message
       end
 
       def message(resource = nil)

--- a/lib/rails_rest_kit/flash_defaults.rb
+++ b/lib/rails_rest_kit/flash_defaults.rb
@@ -1,0 +1,87 @@
+module RailsRestKit
+  class FlashDefaults
+    include Singleton
+
+    def create_valid(params = nil)
+      default_params = { 
+        type: :notice, 
+        message: -> (resource) { "#{resource.model_name.human} was successfully created." } 
+      }
+      if params.nil?
+        @default_create_valid ||= Default.new(default_params)
+      else
+        params.reverse_merge!(default_params)
+        @default_create_valid = Default.new(params[:type], params[:message])
+      end
+    end
+
+    def create_invalid(params = nil)
+      default_params = { 
+        type: :alert, 
+        message: -> (resource) { "#{resource.model_name.human} failed to be created." } 
+      }
+      if params.nil?
+        @default_create_invalid ||= Default.new(default_params)
+      else
+        params.reverse_merge!(default_params)
+        @default_create_invalid = Default.new(params[:type], params[:message])
+      end
+    end
+
+    def update_valid(params = nil)
+      default_params = { 
+        type: :notice, 
+        message: -> (resource) { "#{resource.model_name.human} was successfully updated." } 
+      }
+      if params.nil?
+        @default_update_valid ||= Default.new(default_params)
+      else
+        params.reverse_merge!(default_params)
+        @default_update_valid = Default.new(params[:type], params[:message])
+      end
+    end
+
+    def update_invalid(params = nil)
+      default_params = { 
+        type: :alert, 
+        message: -> (resource) { "#{resource.model_name.human} failed to be updated." } 
+      }
+      if params.nil?
+        @default_update_invalid ||= Default.new(default_params)
+      else
+        params.reverse_merge!(default_params)
+        @default_update_invalid = Default.new(params[:type], params[:message])
+      end
+    end
+
+    def destroy(params = nil)
+      default_params = { 
+        type: :notice, 
+        message: -> (resource) { "#{resource.model_name.human} was successfully destroyed." } 
+      }
+      if params.nil?
+        @default_destroy ||= Default.new(default_params)
+      else
+        params.reverse_merge!(default_params)
+        @default_destroy = Default.new(params[:type], params[:message])
+      end
+    end
+
+    def [](key)
+      send(key)
+    end
+
+    class Default
+      attr_accessor :flash_type, :message_or_block
+
+      def initialize(flash_type, message_or_block)
+        @flash_type = flash_type
+        @message_or_block = message_or_block
+      end
+
+      def message(resource = nil)
+        @message_or_block.is_a?(Proc) ? @message_or_block.call(resource) : @message_or_block
+      end
+    end
+  end
+end

--- a/lib/rails_rest_kit/restful_controller_actions.rb
+++ b/lib/rails_rest_kit/restful_controller_actions.rb
@@ -45,9 +45,11 @@ module RailsRestKit
       run_callbacks(:create) do
         if resource.save
           run_callbacks(:create_valid) do
+            flash_message :create_valid, resource
           end
         else
           run_callbacks(:create_invalid) do
+            flash_message :create_invalid, resource
           end
         end
       end
@@ -65,9 +67,11 @@ module RailsRestKit
       run_callbacks(:update) do
         if resource.save
           run_callbacks(:update_valid) do
+            flash_message :update_valid, resource
           end
         else
           run_callbacks(:update_invalid) do
+            flash_message :update_invalid, resource
           end
         end
       end
@@ -77,7 +81,14 @@ module RailsRestKit
       resource = send("set_#{model_slug}")
       run_callbacks(:destroy) do
         resource.destroy
+        flash_message :destroy, resource
       end
+    end
+
+    def flash_message(key, resource)
+      flash_default = RailsRestKit.config.flash_defaults[key]
+      message = flash_default.message(resource)
+      flash[flash_default.flash_type] = message
     end
 
     class_methods do

--- a/lib/rails_rest_kit/restful_controller_actions.rb
+++ b/lib/rails_rest_kit/restful_controller_actions.rb
@@ -9,7 +9,7 @@ module RailsRestKit
       create: %i[ valid invalid ],
       edit: %i[],
       update: %i[ valid invalid ],
-      destroy: %i[]
+      destroy: %i[ valid invalid ]
     }
 
     included do
@@ -80,8 +80,15 @@ module RailsRestKit
     def default_destroy
       resource = send("set_#{model_slug}")
       run_callbacks(:destroy) do
-        resource.destroy
-        flash_message :destroy, resource
+        if resource.destroy
+          run_callbacks(:destroy_valid) do
+            flash_message :destroy_valid, resource
+          end
+        else
+          run_callbacks(:destroy_invalid) do
+            flash_message :destroy_invalid, resource
+          end
+        end
       end
     end
 

--- a/lib/rails_rest_kit/version.rb
+++ b/lib/rails_rest_kit/version.rb
@@ -1,3 +1,3 @@
 module RailsRestKit
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/rails_rest_kit/restful_controller_action_spec.rb
+++ b/spec/lib/rails_rest_kit/restful_controller_action_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe UsersController, type: :controller do
       controller.class.after_create_valid { callback_order << "after_create_valid" }
       controller.class.after_create_invalid { callback_order << "after_create_invalid" }
       post :create, params: { user: { name: "John Doe", email: "john.doe@example.com" } }
+      expect(flash[:notice]).to eq("User was successfully created.")
       expect(callback_order).to eq(["before_create", "before_create_valid", "after_create_valid", "after_create"])
     end
 
@@ -83,7 +84,19 @@ RSpec.describe UsersController, type: :controller do
       controller.class.after_create_valid { callback_order << "after_create_valid" }
       controller.class.after_create_invalid { callback_order << "after_create_invalid" }
       post :create, params: { user: {} }
+      expect(flash[:alert]).to eq("User failed to be created.")
       expect(callback_order).to eq(["before_create", "before_create_invalid", "after_create_invalid", "after_create"])
+    end
+
+    it "uses flash default overrides" do
+      RailsRestKit.config.flash_defaults.create_valid(type: :alert, message: "Custom message")
+      post :create, params: { user: { name: "John Doe", email: "john.doe@example.com" } }
+      expect(flash[:alert]).to eq("Custom message")
+      expect(flash[:notice]).to be_nil
+      RailsRestKit.config.flash_defaults.create_valid(type: :alert, message: -> (resource) { "Custom message 2" })
+      post :create, params: { user: { name: "Jane Doe", email: "jane.doe@example.com" } }
+      expect(flash[:alert]).to eq("Custom message 2")
+      expect(flash[:notice]).to be_nil
     end
 
     it "sets the user instance variable" do
@@ -129,6 +142,7 @@ RSpec.describe UsersController, type: :controller do
       controller.class.after_update_valid { callback_order << "after_update_valid" }
       controller.class.after_update_invalid { callback_order << "after_update_invalid" }
       put :update, params: { id: user.id, user: { name: "Jane Doe", email: "jane.doe@example.com" } }
+      expect(flash[:notice]).to eq("User was successfully updated.")
       expect(callback_order).to eq(["before_update", "before_update_valid", "after_update_valid", "after_update"])
     end
 
@@ -141,7 +155,19 @@ RSpec.describe UsersController, type: :controller do
       controller.class.after_update_valid { callback_order << "after_update_valid" }
       controller.class.after_update_invalid { callback_order << "after_update_invalid" }
       put :update, params: { id: user.id, user: { name: nil } }
+      expect(flash[:alert]).to eq("User failed to be updated.")
       expect(callback_order).to eq(["before_update", "before_update_invalid", "after_update_invalid", "after_update"])
+    end
+
+    it "uses flash default overrides" do
+      RailsRestKit.config.flash_defaults.update_valid(type: :alert, message: "Custom message")
+      put :update, params: { id: user.id, user: { name: "Test" } }
+      expect(flash[:alert]).to eq("Custom message")
+      expect(flash[:notice]).to be_nil
+      RailsRestKit.config.flash_defaults.update_valid(type: :alert, message: -> (resource) { "Custom message 2" })
+      put :update, params: { id: user.id, user: { name: "Test 2" } }
+      expect(flash[:alert]).to eq("Custom message 2")
+      expect(flash[:notice]).to be_nil
     end
 
     it "sets the user instance variable" do
@@ -163,6 +189,7 @@ RSpec.describe UsersController, type: :controller do
       controller.class.before_destroy { callback_order << "before_destroy" }
       controller.class.after_destroy { callback_order << "after_destroy" }
       delete :destroy, params: { id: user.id }
+      expect(flash[:notice]).to eq("User was successfully destroyed.")
       expect(callback_order).to eq(["before_destroy", "after_destroy"])
     end
 
@@ -170,6 +197,18 @@ RSpec.describe UsersController, type: :controller do
       expect {
         delete :destroy, params: { id: user.id }
       }.to change(User, :count).by(-1)
+    end
+
+    it "uses flash default overrides" do
+      RailsRestKit.config.flash_defaults.destroy(type: :alert, message: "Custom message")
+      delete :destroy, params: { id: user.id }
+      expect(flash[:alert]).to eq("Custom message")
+      expect(flash[:notice]).to be_nil
+      RailsRestKit.config.flash_defaults.destroy(type: :alert, message: -> (resource) { "Custom message 2" })
+      user = User.create!(name: "John Doe", email: "john.doe@example.com")
+      delete :destroy, params: { id: user.id }
+      expect(flash[:alert]).to eq("Custom message 2")
+      expect(flash[:notice]).to be_nil
     end
 
     it "sets the user instance variable" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
     RailsRestKit.config.flash_defaults.create_invalid({})
     RailsRestKit.config.flash_defaults.update_valid({})
     RailsRestKit.config.flash_defaults.update_invalid({})
-    RailsRestKit.config.flash_defaults.destroy({})
+    RailsRestKit.config.flash_defaults.destroy_valid({})
+    RailsRestKit.config.flash_defaults.destroy_invalid({})
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,5 +39,11 @@ RSpec.configure do |config|
     # Clean up data after each test
     User.delete_all
     Post.delete_all
+    # Reset flash defaults after each test
+    RailsRestKit.config.flash_defaults.create_valid({})
+    RailsRestKit.config.flash_defaults.create_invalid({})
+    RailsRestKit.config.flash_defaults.update_valid({})
+    RailsRestKit.config.flash_defaults.update_invalid({})
+    RailsRestKit.config.flash_defaults.destroy({})
   end
 end


### PR DESCRIPTION
#1

Adds default flash messages to default REST actions, which can be configured using `config.flash_defaults`.